### PR TITLE
Change visibility of detectType method

### DIFF
--- a/src/adapters/StiDataAdapter.php
+++ b/src/adapters/StiDataAdapter.php
@@ -123,7 +123,7 @@ class StiDataAdapter
         return $value;
     }
 
-    private function detectType($value)
+    protected function detectType($value)
     {
         if (preg_match('~[^\x20-\x7E\t\r\n]~', $value) > 0)
             return 'array';


### PR DESCRIPTION
The detectType method was protected in older versions, so I could override it to handle some custom firebird datatypes that are not well recognized by your method.