### PR TITLE
Update StiServiceProvider.php

### DIFF
--- a/src/laravel/StiServiceProvider.php
+++ b/src/laravel/StiServiceProvider.php
@@ -9,7 +9,7 @@ if (class_exists('\Illuminate\Support\ServiceProvider'))
 		public function boot()
 		{
 			\Illuminate\Support\Facades\Route::get('/vendor/stimulsoft/reports-php/scripts/{file}', function ($file) {
-				return file_get_contents(__DIR__ . "/../../scripts/$file");
+				return response()->file(__DIR__ . "/../../scripts/$file", ["Content-Type"=>'text/javascript']);
 			});
 		}
 	}


### PR DESCRIPTION
Fixed Below Code issue for getting content as html instead of javascript. Refused to execute script from 'https://stimulsoft-report.test/vendor/stimulsoft/reports-php/scripts/stimulsoft.reports.js' because its MIME type ('text/html') is not executable, and strict MIME type checking is enabled.
<img width="959" alt="Screenshot 2023-12-11 at 3 47 56 PM" src="https://github.com/stimulsoft/Stimulsoft.Reports.PHP/assets/11732316/5366eafa-99bd-464a-bea2-ff0b3352f6bd">
